### PR TITLE
Enable Image Scan and Introduce Non Strict Mode

### DIFF
--- a/mq/environments/ci/pipelines/mq-pipeline-dev.yaml
+++ b/mq/environments/ci/pipelines/mq-pipeline-dev.yaml
@@ -29,6 +29,12 @@ spec:
     - name: git-pr
       description: Enable the pipeline to do a PR for the gitops repo
       default: "false"
+    - name: detect-secrets-strict-mode
+      description: If detect-secrets-strict-mode is true and potential secrets detected, the step will be failed.
+      default: "false"
+    - name: img-scan-strict-mode
+      description: If img-scan-strict-mode is true and potential issue found, the step will be failed.
+      default: "false"
   tasks:
     - name: setup
       taskRef:
@@ -52,6 +58,8 @@ spec:
           value: "$(tasks.setup.results.git-revision)"
         - name: source-dir
           value: "$(tasks.setup.results.source-dir)"
+        - name: detect-secrets-strict-mode
+          value: $(params.detect-secrets-strict-mode)
     - name: build
       taskRef:
         name: ibm-build-tag-push-v2-6-13
@@ -140,6 +148,8 @@ spec:
           value: $(tasks.setup.results.scan-trivy)
         - name: scan-ibm
           value: $(tasks.setup.results.scan-ibm)
+        - name: img-scan-strict-mode
+          value: $(params.img-scan-strict-mode)
     - name: helm-release
       taskRef:
         name: ibm-helm-release-v2-6-13

--- a/mq/environments/ci/tasks/ibm-detect-secrets-v2-6-13.yaml
+++ b/mq/environments/ci/tasks/ibm-detect-secrets-v2-6-13.yaml
@@ -17,8 +17,8 @@ spec:
     - name: source-dir
       default: /source
     - name: detect-secrets-strict-mode
-      description: If detect-secrets-strict-mode is True and potential secrets detected, the step will be failed.
-      default: "False"
+      description: If detect-secrets-strict-mode is true and potential secrets detected, the step will be failed.
+      default: "false"
   volumes:
     - name: source
       emptyDir: {}
@@ -89,11 +89,11 @@ spec:
             print('FOUND SECRETS:')
             for secret in found_secrets:
                 print('File: ' + secret[0] + ' Line: ' + str(secret[1]['line_number']) + ' Type: ' + secret[1]['type'])  # noqa: E501
-            if detect_mode == "True":
+            if detect_mode == "true":
                 print('\nERROR: Detect Secrets Failure.')
                 sys.exit(1)
             else:
-                print("\nWARNING: the step exits successfully with above issue due to the environment variable DETECT_SECRETS_STRICT_MODE is not True.")
+                print("\nWARNING: the step exits finally with above issue due to the detect-secrets-strict-mode is not true.")
         else:
             print('NO SECRETS FOUND')
             print('Detect Secrets Success')

--- a/mq/environments/ci/tasks/ibm-img-scan-v2-6-13.yaml
+++ b/mq/environments/ci/tasks/ibm-img-scan-v2-6-13.yaml
@@ -27,6 +27,9 @@ spec:
       default: quay.io/ibmgaragecloud/aquasec-trivy
     - name: tools-image
       default: quay.io/ibmgaragecloud/ibmcloud-dev:v2.0.4
+    - name: img-scan-strict-mode
+      description: If img-scan-strict-mode is true and potential issue found, the step will be failed.
+      default: "false"
   volumes:
     - name: oci-image
       emptyDir: {}
@@ -82,19 +85,25 @@ spec:
       script: |
           set -ex
           PERFORM_SCAN="$(params.scan-trivy)"
+          SCAN_MODE="$(params.img-scan-strict-mode)"
           if [[ "${PERFORM_SCAN}" == "false" ]] || [[ -z "${PERFORM_SCAN}" ]]; then
             echo "User selected to skip scanning. Skipping Trivy scan."
             exit 0
           fi
           PATH_TO_IMAGE="/var/oci/image"
           echo -e "Trivy Security Scan image in registry"
+          set +e
           trivy image --exit-code 0 --input ${PATH_TO_IMAGE}
           trivy image --exit-code 1 --severity CRITICAL --input ${PATH_TO_IMAGE}
           my_exit_code=$?
           echo "Scan exit code :--- $my_exit_code"
           if [ ${my_exit_code} == 1 ]; then
               echo "Trivy scanning completed. CRITICAL Vulnerabilities found."
-              exit 1
+              if [ "${SCAN_MODE}" == "true" ]; then
+                exit 1
+              else
+                echo -e "\nWARNING: the step exits finally with above issue due to the img-scan-strict-mode is not true."
+              fi
           else
             echo "Trivy scanning completed. CRITICAL vulnerabilities not found."
           fi
@@ -119,6 +128,7 @@ spec:
           #!/usr/bin/env bash
           set -ex
           PERFORM_SCAN="$(params.scan-ibm)"
+          SCAN_MODE="$(params.img-scan-strict-mode)"
           if [[ "${PERFORM_SCAN}" == "false" ]] || [[ -z "${PERFORM_SCAN}" ]]; then
             echo "User selected to skip scanning. Skipping Vulnerability Advisor validation."
             exit 0
@@ -170,7 +180,11 @@ spec:
           elif [[ $(cat va-result.json | jq -r '.[].vulnerabilities | length') -gt 0 ]]; then
             echo "VA Failure: $(cat va-result.json | jq -r '.[].vulnerabilities | length') vulnerabilities found in the image"
             cat va-result.json | jq -r '.[].vulnerabilities'
-            exit 1
+            if [ "${SCAN_MODE}" == "true" ]; then
+              exit 1
+            else
+              echo -e "\nWARNING: the step exits finally with above issue due to the img-scan-strict-mode is not true."
+            fi
           elif [[ $(cat va-result.json | jq -r '.[].configuration_issues | length') -gt 0 ]]; then
             echo "VA Warning - $(cat va-result.json | jq -r '.[].configuration_issues | length') configuration issues found in the image"
             cat va-result.json | jq -r '.[].configuration_issues'

--- a/mq/environments/ci/triggertemplates/mq-infra-dev.yaml
+++ b/mq/environments/ci/triggertemplates/mq-infra-dev.yaml
@@ -21,5 +21,7 @@ spec:
         value: $(tt.params.gitrepositoryurl)
       - name: git-revision
         value: $(tt.params.gitrevision)
+      - name: scan-image
+        value: 'true'
       pipelineRef:
         name: mq-infra-dev


### PR DESCRIPTION
Due to we would like to demo the DevSecOps, the `image scan` is import step, but now the `image scan` is disabled, otherwise the step will be failed and that cause CI pipeline failed.

The PR is going to enable image scan, to avoid CI pipeline failed, we introduce a Non strict mode, in this mode, the image will be scan and report, but the step will be passed. If set to strict mode, the step will failed if issue found while scanning.

Only updated `mq-pipeline-dev` for demo, do not update others.
